### PR TITLE
chore: bump Vib action to v0.6.2

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.2-2
+    - uses: vanilla-os/vib-gh-action@v0.6.2
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/waydroid:main .

--- a/.github/workflows/vib-pr.yml
+++ b/.github/workflows/vib-pr.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.2-2
+    - uses: vanilla-os/vib-gh-action@v0.6.2
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag vanillaos/waydroid .

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,101 +1,104 @@
-base: ghcr.io/vanilla-os/pico:main
 name: Waydroid
 id: waydroid
-labels:
-  maintainer: Vanilla OS Contributors
-args:
-  DEBIAN_FRONTEND: noninteractive
-runs:
-- echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
+stages:
+- id: build
+  base: ghcr.io/vanilla-os/pico:main
+  singlelayer: false
+  labels:
+    maintainer: Vanilla OS Contributors
+  args:
+    DEBIAN_FRONTEND: noninteractive
+  runs:
+  - echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
 
-modules:
-  - name: dependencies
-    type: apt
-    source:
-      packages:
-      - systemd
-      - libpam-systemd
-      - curl
-      - kmod
-      - dbus-x11
-      - iptables
-      - mutter
-
-  - name: distrobox-init-pkgs
-    type: apt
-    source:
-      packages:
-        - apt-utils
-        - bash-completion
-        - bc
-        - bzip2
+  modules:
+    - name: dependencies
+      type: apt
+      source:
+        packages:
+        - systemd
+        - libpam-systemd
         - curl
-        - dialog
-        - diffutils
-        - findutils
-        - iproute2
-        - gnupg
-        - gnupg2
-        - gpgsm
-        - libkrb5-3
-        - libcap2-bin
-        - hostname
-        - iputils-ping
-        - less
-        - keyutils
-        - libnss-mdns
-        - libnss-myhostname
-        - libvte-2.9*-common
-        - libvte-common
-        - locales
-        - locales-all
-        - man-db
-        - manpages
-        - mtr
-        - lsof
-        - ncurses-base
-        - passwd
-        - pinentry-curses
-        - openssh-client
-        - procps
-        - sudo
-        - pigz
-        - time
-        - rsync
-        - tzdata
-        - util-linux
-        - wget
-        - unzip
-        - zip
-        - xauth
-        - tree
-        - tcpdump
-        - traceroute
-        - xz-utils
-        - libgl1
-        - libegl1-mesa
-        - libgl1-mesa-glx
-        - libegl1
-        - libglx-mesa0
-        - libvulkan1
-        - mesa-vulkan-drivers
+        - kmod
+        - dbus-x11
+        - iptables
+        - mutter
 
-  - name: waydroid-repo
-    type: shell
-    commands:
-      - curl --progress-bar --proto '=https' --tlsv1.2 -Sf https://repo.waydro.id/waydroid.gpg --output /usr/share/keyrings/waydroid.gpg
-      - echo "deb [signed-by=/usr/share/keyrings/waydroid.gpg] https://repo.waydro.id/ bookworm main" | tee /etc/apt/sources.list.d/waydroid.list
-      - apt update
+    - name: distrobox-init-pkgs
+      type: apt
+      source:
+        packages:
+          - apt-utils
+          - bash-completion
+          - bc
+          - bzip2
+          - curl
+          - dialog
+          - diffutils
+          - findutils
+          - iproute2
+          - gnupg
+          - gnupg2
+          - gpgsm
+          - libkrb5-3
+          - libcap2-bin
+          - hostname
+          - iputils-ping
+          - less
+          - keyutils
+          - libnss-mdns
+          - libnss-myhostname
+          - libvte-2.9*-common
+          - libvte-common
+          - locales
+          - locales-all
+          - man-db
+          - manpages
+          - mtr
+          - lsof
+          - ncurses-base
+          - passwd
+          - pinentry-curses
+          - openssh-client
+          - procps
+          - sudo
+          - pigz
+          - time
+          - rsync
+          - tzdata
+          - util-linux
+          - wget
+          - unzip
+          - zip
+          - xauth
+          - tree
+          - tcpdump
+          - traceroute
+          - xz-utils
+          - libgl1
+          - libegl1-mesa
+          - libgl1-mesa-glx
+          - libegl1
+          - libglx-mesa0
+          - libvulkan1
+          - mesa-vulkan-drivers
 
-  - name: waydroid
-    type: apt
-    source:
-      packages:
-      - waydroid
+    - name: waydroid-repo
+      type: shell
+      commands:
+        - curl --progress-bar --proto '=https' --tlsv1.2 -Sf https://repo.waydro.id/waydroid.gpg --output /usr/share/keyrings/waydroid.gpg
+        - echo "deb [signed-by=/usr/share/keyrings/waydroid.gpg] https://repo.waydro.id/ bookworm main" | tee /etc/apt/sources.list.d/waydroid.list
+        - apt update
 
-  - name: set-environment
-    type: shell
-    commands:
-      - rm -rf /lib/modules
-      - ln -sf /run/host/lib/modules /lib/modules
-      - chmod +x /usr/bin/ewaydroid
+    - name: waydroid
+      type: apt
+      source:
+        packages:
+        - waydroid
+
+    - name: set-environment
+      type: shell
+      commands:
+        - rm -rf /lib/modules
+        - ln -sf /run/host/lib/modules /lib/modules
+        - chmod +x /usr/bin/ewaydroid


### PR DESCRIPTION
## Changes

- Bump Vib action to `v0.6.2`.
- Update `recipe.yml` to the new syntax.