### PR TITLE
feat: use waydroid props from config file

### DIFF
--- a/includes.container/usr/bin/ewaydroid
+++ b/includes.container/usr/bin/ewaydroid
@@ -4,4 +4,24 @@
 export XDG_RUNTIME_DIR="/run/host/${XDG_RUNTIME_DIR}"
 export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/host/$(echo "${DBUS_SESSION_BUS_ADDRESS}" | cut -d '=' -f2-)"
 
+source ~/.config/waydroid-props
+
+if [[ "$1" != "init" && ! $# -eq 0 ]]; then
+    if waydroid status | grep STOPPED; then
+	waydroid session start &
+	sleep 7
+    fi
+    
+    waydroid prop set persist.waydroid.multi_windows ${multi_window:-true}
+    waydroid prop set persist.waydroid.cursor_on_subsurface ${cursor_on_subsurface:-false}
+    if [[ ! -z ${height_padding+x} ]]; then waydroid prop set persist.waydroid.height_padding ${height_padding}; fi
+    if [[ ! -z ${width_padding+x} ]]; then waydroid prop set persist.waydroid.width_padding ${width_padding}; fi
+    if [[ ! -z ${width+x} ]]; then waydroid prop set persist.waydroid.width ${width}; fi
+    if [[ ! -z ${height+x} ]]; then waydroid prop set persist.waydroid.height ${height}; fi
+    waydroid prop set persist.waydroid.suspend ${suspend_:-true}
+    waydroid prop set persist.waydroid.uevent ${uevent:-false}
+    waydroid prop set persist.waydroid.fake_touch ${fake_touch:-""}
+    waydroid prop set persist.waydroid.fake_wifi ${fake_wifi:-""}
+fi
+
 waydroid "$@"


### PR DESCRIPTION
To allow the user to modify waydroid props they can edit the file ~/.config/waydroid-pros which get sourced by ewaydroid every time a command is issued